### PR TITLE
Updating to latest statick release.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ghcr.io/sscpac/statick:0.6.2
+FROM ghcr.io/sscpac/statick:0.7.2
 
 LABEL "name"="Statick Action"
-LABEL "version"="0.6.2"
+LABEL "version"="0.7.2"
 LABEL "repository"="https://github.com/sscpac/statick-action.git"
 LABEL "homepage"="https://github.com/sscpac/statick-action"
 LABEL "maintainer"="Thomas Denewiler <tdenewiler@gmail.com>"


### PR DESCRIPTION
The automatic Docker image creation on new release appears to have worked nicely, making this easy.